### PR TITLE
remove .env file from public repo

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-MONGODB_URI=mongodb://127.0.0.1:27017/leetcode-api
-JWT_SECRET_KEY=bbebbf33f4467751abd9ab02d3d042c01fac2aaf94033cabac56353c5cf8adaa
-JWT_EXPIRES_IN=60

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env*.local
+.env
+*.local
 
 # vercel
 .vercel


### PR DESCRIPTION
For the sake of security, we should never have a .env file in the public repository. 