### PR TITLE
Fix redirect after auth issue with server side set http only cookie

### DIFF
--- a/src/app/api/user/auth/register/route.ts
+++ b/src/app/api/user/auth/register/route.ts
@@ -14,7 +14,6 @@ export async function POST(req: Request) {
       { status: 201 }
     );
   } catch (error) {
-    console.log("register error but still redirects why?");
     return errorResponseHandler(error as CustomError);
   }
 }

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,12 +1,19 @@
 "use client";
 import { useAuth } from "@/context/authContext";
 import { fetchLeetcodeData } from "@/lib/clients/leetcode";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 function UserPage() {
   const [username, setUsername] = useState<string>("gambhir-harshil");
   const [userStats, setUserStats] = useState<any>(undefined);
-  const { logout } = useAuth();
+  const { apiLogout } = useAuth();
+  const router = useRouter();
+
+  const userLogout = async () => {
+    await apiLogout();
+    router.push("/login");
+  };
 
   async function fetchData(e?: any) {
     e?.preventDefault();
@@ -47,7 +54,7 @@ function UserPage() {
           </ul>
           <br />
           <br />
-          <button onClick={logout}>Logout</button>
+          <button onClick={userLogout}>Logout</button>
         </div>
       ) : (
         <p>Loading...</p>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,11 +4,7 @@ import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import Loader from "../../components/Loader";
-import {
-  LoginPayloadType,
-  RegisterPayloadType,
-  useAuth,
-} from "@/context/authContext";
+import { LoginPayloadType, useAuth } from "@/context/authContext";
 
 export default function Login() {
   const validationSchema = Yup.object().shape({
@@ -18,14 +14,14 @@ export default function Login() {
 
   const formOptions = { resolver: yupResolver(validationSchema) };
 
-  const { register, handleSubmit, reset, formState } = useForm(formOptions);
+  const { register, handleSubmit, formState } = useForm(formOptions);
   const { errors, isSubmitting } = formState;
 
-  const { login } = useAuth();
+  const { apiAuthenticate } = useAuth();
 
   const submitHandler = async (data: LoginPayloadType) => {
     try {
-      await login(data);
+      await apiAuthenticate("userLogin", data);
     } catch (err) {
       console.log(err);
     }

--- a/src/app/register/registerForm.tsx
+++ b/src/app/register/registerForm.tsx
@@ -5,7 +5,6 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import * as Yup from "yup";
 import Loader from "../../components/Loader";
 import { RegisterPayloadType, useAuth } from "@/context/authContext";
-import { useRouter } from "next/navigation";
 
 const RegisterForm = () => {
   const validationSchema = Yup.object().shape({
@@ -24,13 +23,11 @@ const RegisterForm = () => {
   const { register, handleSubmit, reset, formState } = useForm(formOptions);
   const { errors, isSubmitting } = formState;
 
-  const { registerUser } = useAuth();
-  const router = useRouter();
+  const { apiAuthenticate } = useAuth();
 
   const submitHandler = async (data: RegisterPayloadType) => {
     try {
-      await registerUser(data);
-      router.push("/leaderboard");
+      await apiAuthenticate("userRegister", data);
     } catch (error: any) {
       console.error("error registering...", error, error?.response);
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,14 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import CustomError from "@/lib/types/errors";
-import { verifyAccessToken } from "@/lib/services/authService";
 import { errorResponseHandler } from "@/lib/helpers";
 import { verifyJWT } from "./lib/token";
 
 export async function middleware(req: NextRequest) {
   try {
-    const href = req.nextUrl.href;
-    if (href.includes("/leaderboard") || href.includes("/profile")) {
+    const url = req.nextUrl;
+    if (url.href.includes("/leaderboard") || url.href.includes("/profile")) {
       if (!req.cookies.has("session")) {
+        if (url.searchParams.get("justAuthenticated"))
+          return NextResponse.next();
         return NextResponse.redirect(new URL("login", req.url));
       }
       const accessToken = req.cookies.get("session")?.value;


### PR DESCRIPTION
Cookie is set from the server and middleware does not have immediate access to cookie unless a full reload is made. The app will assume a successful authentication after authentications endpoint calls respond with an 'ok' i.e. successfully and append query parameter "?justAuthenticated=true", while maintaining middleware guard for protected routes.